### PR TITLE
fix(game): avoid roll action option when hand full

### DIFF
--- a/backend/src/game.py
+++ b/backend/src/game.py
@@ -46,12 +46,12 @@ class GameState:
             # Return no available actions when the round had been stopped
             return []
 
+        if len(self.hand) >= self.N_DICE:
+            return [Action(Action.STOP)]
+
         if not self.dice_throw:
             actions = [Action(Action.ROLL), Action(Action.STOP)]
             return actions
-
-        if len(self.hand) >= self.N_DICE:
-            return [Action(Action.STOP)]
 
         if self.dice_throw:
             die_options = []

--- a/backend/tests/test_full_hand_regression.py
+++ b/backend/tests/test_full_hand_regression.py
@@ -1,0 +1,32 @@
+from src.game import Action, GameState
+from src.tree import MCTS
+
+
+def test_mcts_full_hand_no_index_error():
+    """
+    Regression test for the IndexError: list index out of range bug.
+    When a hand is full (8 dice), get_available_actions should not return ROLL,
+    which prevents MCTS from creating a ChanceNode with 0 possible rolls.
+    """
+    # Create a state with 8 dice in hand (full)
+    full_hand = [1, 2, 3, 4, 5, 6, 1, 2]
+    state = GameState(hand=full_hand, dice_throw=[], score=0.0)
+
+    # 1. Verify GameState logic directly
+    actions = state.get_available_actions()
+    assert (
+        Action(Action.ROLL) not in actions
+    ), "ROLL should not be available when hand is full"
+    assert Action(Action.STOP) in actions, "STOP should be available when hand is full"
+
+    # 2. Verify MCTS can run without crash
+    mcts = MCTS(state)
+    # The crash used to happen during simulation/expansion phase
+    # Running a reasonable number of simulations to ensure we touch all paths
+    try:
+        mcts.run(num_simulations=100)
+    except IndexError as e:
+        assert False, f"MCTS crashed with IndexError: {e}"
+    except Exception as e:
+        # We don't expect other exceptions but if they happen they should be caught or fail the test
+        assert False, f"MCTS crashed with unexpected exception: {e}"


### PR DESCRIPTION
I have fixed the bug where the MCTS simulation would crash with an IndexError.

The Issue:
The GameState.get_available_actions method was incorrectly allowing the ROLL action when the player's hand was already full (8 dice) as long as there were no dice currently on the table (dice_throw was empty). This led to MCTS creating a ChanceNode for rolling, but get_possible_rolls correctly returned an empty list because there were 0 dice left to roll. This empty list caused random.choices to fail with IndexError: list index out of range when trying to pick an outcome.

The Fix:
I updated backend/src/game.py to check if the hand is full (len(self.hand) >= self.N_DICE) before checking if a roll is possible. Now, if the hand is full, only the STOP action is available, preventing the invalid state from being reached.

I verified the fix with a test case confirming that a full hand only offers the STOP action.